### PR TITLE
Fix test correctness and flakiness

### DIFF
--- a/lsp-client/lsp-client.cabal
+++ b/lsp-client/lsp-client.cabal
@@ -43,6 +43,7 @@ common common
         aeson,
         base,
         bytestring,
+        lens,
         lsp-types,
 
 library
@@ -59,7 +60,6 @@ library
         filepath,
         generic-lens,
         hashable,
-        lens,
         lifted-async,
         lsp,
         mtl,

--- a/lsp-client/lsp-client.cabal
+++ b/lsp-client/lsp-client.cabal
@@ -44,7 +44,6 @@ common common
         base,
         bytestring,
         lsp-types,
-        text,
 
 library
     import:           common
@@ -65,6 +64,7 @@ library
         lsp,
         mtl,
         stm,
+        text,
         unliftio,
         unordered-containers,
     if os(windows)
@@ -89,11 +89,9 @@ test-suite spec
         QuickCheck,
         extra,
         ghcide,
-        haskell-language-server,
         hspec,
         lsp-client,
         process,
         unliftio,
-        uuid
     other-modules:
         Language.LSP.ClientSpec

--- a/lsp-client/test/Language/LSP/ClientSpec.hs
+++ b/lsp-client/test/Language/LSP/ClientSpec.hs
@@ -159,10 +159,8 @@ spec = do
                 req1Id <- sendRequest SShutdown Empty (putMVar req1Done . (._id))
                 req2Done <- newEmptyMVar
                 req2Id <- sendRequest SShutdown Empty (putMVar req2Done . (._id))
-                tryTakeMVar req1Done `shouldReturn` Nothing
-                tryTakeMVar req2Done `shouldReturn` Nothing
                 withTimeout 100_000 $ takeMVar req1Done `shouldReturn` Just req1Id
-                withTimeout 5_000 $ takeMVar req2Done `shouldReturn` Just req2Id
+                withTimeout 100_000 $ takeMVar req2Done `shouldReturn` Just req2Id
     prop "opens and changes virtual documents correctly" $ do
         bracket
             notifServer

--- a/lsp-client/test/Language/LSP/ClientSpec.hs
+++ b/lsp-client/test/Language/LSP/ClientSpec.hs
@@ -9,15 +9,9 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Types (parseMaybe)
 import Data.ByteString (ByteString, hGetSome)
 import Data.ByteString.Builder.Extra (defaultChunkSize)
-import Data.ByteString.Char8 qualified as ByteString
 import Data.ByteString.Lazy qualified as LazyByteString
 import Data.Maybe (fromJust)
-import Data.Text qualified as Text
-import Data.UUID qualified as UUID
-import Data.UUID.V4 qualified as UUID
 import Development.IDE
-import Development.IDE.Main
-import HlsPlugins (idePlugins)
 import Language.LSP.Client
 import Language.LSP.Client.Decoding (getNextMessage)
 import Language.LSP.Client.Encoding (encode)
@@ -105,29 +99,17 @@ reqServer = do
             putMVar lock ()
     pure (inWrite, outRead, threadId)
 
--- | LSP server that accepts requests and answers them with a delay
-hls :: IO (Handle, Handle, Handle, ThreadId)
-hls = do
+-- | LSP server that reads messages, and does nothing else
+notifServer :: IO (Handle, Handle, ThreadId)
+notifServer = do
     (inRead, inWrite) <- createPipe
     hSetBuffering inRead LineBuffering
     hSetBuffering inWrite LineBuffering
-    (outRead, outWrite) <- createPipe
+    (outRead, _) <- createPipe
     hSetBuffering outRead LineBuffering
-    hSetBuffering outWrite LineBuffering
-    (errRead, errWrite) <- createPipe
-    hSetBuffering errRead LineBuffering
-    hSetBuffering errWrite LineBuffering
-    let recorder = Recorder{logger_ = liftIO . hPrint errWrite . payload}
-        logger = Logger $ logWith recorder
-        recorder' = cmapWithPrio (Text.pack . show . pretty) recorder
-        plugins = idePlugins $ cmapWithPrio (Text.pack . show . pretty) recorder
-        arguments =
-            (defaultArguments recorder' logger plugins)
-                { argsHandleIn = pure stdin
-                , argsHandleOut = pure stdout
-                }
-    threadId <- forkIO $ defaultMain recorder' arguments
-    pure (inWrite, outRead, errRead, threadId)
+    threadId <- forkIO $ forever $ do
+        liftIO $ getNextMessage inRead
+    pure (inWrite, outRead, threadId)
 
 -- | LSP client that waits for queries
 client :: Handle -> Handle -> IO (Session () -> IO (), ThreadId)
@@ -174,16 +156,12 @@ spec = do
                 withTimeout 5_000 $ takeMVar req2Done `shouldReturn` Just req2Id
     prop "opens and changes virtual documents correctly" $ do
         bracket
-            hls
-            ( \(_, _, serverErr, threadId) -> do
-                killThread threadId
-                getAvailableContents serverErr >>= hPutStrLn stderr . ByteString.unpack
-            )
-            $ \(serverIn, serverOut, _, _) -> runSessionWithHandles serverOut serverIn $ do
-                uuid <- liftIO UUID.nextRandom
-                let file = Text.unpack $ UUID.toText uuid <> ".hs"
-                LSP.initialize
-                threadDelay 100_000
-                doc <- LSP.createDoc file "haskell" ""
-                threadDelay 100_000
+            notifServer
+            (\(_, _, threadId) -> killThread threadId)
+            $ \(serverIn, serverOut, _) -> runSessionWithHandles serverOut serverIn $ do
+                doc <- LSP.createDoc "TestFile.hs" "haskell" ""
                 LSP.documentContents doc `shouldReturn` (Just "")
+                changeDoc doc [TextDocumentContentChangeEvent Nothing Nothing "foo"]
+                LSP.documentContents doc `shouldReturn` (Just "foo")
+                closeDoc doc
+                LSP.documentContents doc `shouldReturn` Nothing

--- a/lsp-client/test/Language/LSP/ClientSpec.hs
+++ b/lsp-client/test/Language/LSP/ClientSpec.hs
@@ -149,8 +149,6 @@ spec = do
             diagServer
             (\(_, _, threadId) -> killThread threadId)
             $ \(serverIn, serverOut, _) -> runSessionWithHandles serverOut serverIn $ do
-                -- Initially the diagnostics should be empty
-                getDiagnostics `shouldReturn` []
                 -- We allow up to 0.1 s to receive the first batch of diagnostics
                 withTimeout 100_000 $ whileM $ do
                     threadDelay 1_000


### PR DESCRIPTION
- Fix flakiness in `concurrently handles actions and server messages`
- Fix implementation of `opens and changes virtual documents correctly`: a full HLS is not needed, as VFS is handled client-side