### PR TITLE
flake.nix: Remove extra-experimental-features

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "dosh: the power of Haskell in your terminal!";
 
   nixConfig = {
-    extra-experimental-features = "nix-command flakes";
     extra-substituters = "https://dosh.cachix.org";
     extra-trusted-public-keys = "dosh.cachix.org-1:wRNFshU1IQW71/P0ueRqOdPqzsff/eGNl2MNKpsZy/o=";
   };


### PR DESCRIPTION
I'd think this is redundant, because to use the flake in a `nix` command you need this feature already enabled on the system anyway.